### PR TITLE
Organize /frontend structure

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,259 @@
+# Total Life Daily - Frontend
+
+Next.js frontend for the Total Life Daily health and wellness blog platform.
+
+## Project Overview
+
+A modern, responsive web application that mirrors the functionality
+of [daily.totallife.com](https://daily.totallife.com/), featuring:
+
+- Health and wellness blog articles
+- AI-powered search with streaming responses
+- Category-based content organization (5 pillars: Nourishment, Restoration, Mindset, Relationships, Vitality)
+- Podcast episodes section
+- Newsletter subscription
+
+## Tech Stack
+
+- **Framework**: Next.js 15 (App Router)
+- **Language**: TypeScript
+- **Styling**: Tailwind CSS + shadcn/ui
+- **Animations**: Framer Motion
+- **Compiler**: React Compiler enabled
+- **Backend**: FastAPI (separate `/backend` directory)
+
+## Project Structure
+
+```
+frontend/
+├── app/                          # Next.js App Router
+│   ├── layout.tsx               # Root layout with Header/Footer
+│   ├── page.tsx                 # Homepage
+│   ├── globals.css              # Global styles (Tailwind, resets, CSS variables only)
+│   ├── blog/
+│   │   └── [slug]/
+│   │       └── page.tsx         # Individual article page
+│   ├── category/
+│   │   └── [category]/
+│   │       └── page.tsx         # Category listing page
+│   ├── search/
+│   │   └── page.tsx             # AI search interface
+│   └── api/                     # Next.js API routes (optional)
+│
+├── components/                   # React components (modular structure)
+│   ├── ui/                      # shadcn/ui components
+│   │   ├── button.tsx
+│   │   ├── card.tsx
+│   │   └── ...                  # Add components with: npx shadcn@latest add
+│   ├── common/                  # Custom reusable UI components
+│   │   ├── Loading/
+│   │   │   ├── Loading.tsx
+│   │   │   └── index.ts
+│   │   └── Badge/
+│   │       ├── Badge.tsx
+│   │       └── index.ts
+│   ├── layout/                  # Layout components
+│   │   ├── Header.tsx
+│   │   ├── Footer.tsx
+│   │   ├── Navigation.tsx
+│   │   └── Sidebar.tsx
+│   ├── blog/                    # Blog-specific components
+│   │   ├── ArticleCard.tsx
+│   │   ├── ArticleGrid.tsx
+│   │   ├── ArticleHero.tsx
+│   │   ├── CategoryBadge.tsx
+│   │   └── ArticleContent.tsx
+│   ├── search/                  # AI search components
+│   │   ├── SearchBar.tsx
+│   │   ├── SearchResults.tsx
+│   │   ├── AIResponse.tsx       # Streaming response with waterfall effect
+│   │   └── SearchSuggestions.tsx
+│   ├── podcast/                 # Podcast components
+│   │   ├── PodcastCard.tsx
+│   │   ├── PodcastPlayer.tsx
+│   │   └── EpisodeList.tsx
+│   └── forms/                   # Form components
+│       ├── NewsletterForm.tsx
+│       ├── ContactForm.tsx
+│       └── FormControls.tsx
+│
+├── lib/                         # Utilities and helpers
+│   ├── api/                     # API client functions
+│   │   ├── client.ts            # Base HTTP client
+│   │   ├── articles.ts          # Article endpoints
+│   │   ├── search.ts            # AI search endpoints
+│   │   └── categories.ts        # Category endpoints
+│   ├── utils/                   # Utility functions
+│   │   ├── cn.ts                # Class name utility (clsx + tailwind-merge)
+│   │   ├── formatters.ts        # Date/text formatting
+│   │   ├── validators.ts        # Validation helpers
+│   │   ├── constants.ts         # App constants
+│   │   └── index.ts             # Central export
+│   └── hooks/                   # Custom React hooks
+│       ├── useArticles.ts
+│       ├── useSearch.ts
+│       ├── useDebounce.ts
+│       └── useIntersectionObserver.ts
+│
+├── types/                       # TypeScript type definitions
+│   ├── article.ts               # Article types
+│   ├── search.ts                # Search types
+│   ├── podcast.ts               # Podcast types
+│   ├── common.ts                # Common types
+│   └── index.ts                 # Central export
+│
+├── public/                      # Static assets
+│   ├── images/
+│   ├── fonts/
+│   └── icons/
+│
+└── README.md                    # This file
+```
+
+## Key Features
+
+### 1. Blog Articles
+
+- Featured hero articles on homepage
+- Category-based filtering
+- Individual article pages with rich content
+- Related articles suggestions
+
+### 2. AI-Powered Search
+
+- Real-time search with streaming responses
+- ChatGPT-style waterfall text effect
+- Source citations and related articles
+- Search suggestions and autocomplete
+
+### 3. Categories (5 Pillars)
+
+- **Nourishment**: Nutrition and diet
+- **Restoration**: Sleep and recovery
+- **Mindset**: Mental health and mindfulness
+- **Relationships**: Social connections
+- **Vitality**: Physical activity and movement
+
+### 4. Podcast Section
+
+- "Mind My Age" podcast episodes
+- Multi-platform links (YouTube, Spotify, Apple Podcasts)
+- Audio/video player integration
+
+### 5. Newsletter Subscription
+
+- Email capture form
+- Name and phone optional fields
+
+## Development
+
+### Prerequisites
+
+- Node.js 18+ installed
+- npm or yarn package manager
+
+### Getting Started
+
+```bash
+# Navigate to frontend directory
+cd frontend
+
+# Install dependencies
+npm install
+
+# Run development server
+npm run dev
+
+# Build for production
+npm run build
+
+# Start production server
+npm start
+```
+
+The app will be available at `http://localhost:3000`
+
+### Environment Variables
+
+Create a `.env.local` file:
+
+```env
+# Backend API URL
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Optional: Analytics, etc.
+NEXT_PUBLIC_GA_ID=
+```
+
+## Backend Integration
+
+The frontend communicates with a FastAPI backend located in `/backend`.
+
+### Expected API Endpoints:
+
+- `GET /api/articles` - List articles with pagination
+- `GET /api/articles/:slug` - Get single article
+- `GET /api/categories` - List categories
+- `GET /api/categories/:category/articles` - Articles by category
+- `POST /api/search` - AI-powered search (streaming)
+- `GET /api/podcast/episodes` - List podcast episodes
+- `POST /api/newsletter/subscribe` - Newsletter signup
+
+## Styling Guidelines
+
+### Style Stack
+
+- **Tailwind CSS**: Utility-first styling
+- **shadcn/ui**: Pre-built accessible components with Radix UI primitives
+- **Framer Motion**: Smooth animations and transitions
+- **CSS Modules**: Optional for complex component-specific styles
+
+### Adding shadcn Components
+
+```bash
+# Add individual components as needed
+npx shadcn@latest add button
+npx shadcn@latest add card
+npx shadcn@latest add input
+```
+
+### Animation Guidelines
+
+- Use Framer Motion for:
+    - Page transitions
+    - Component entrance/exit animations
+    - Scroll-triggered animations
+    - Gesture interactions
+- Keep animations subtle and performant (< 300ms for most)
+- Waterfall text effect for AI search responses
+
+### Design Principles
+
+- Follow mobile-first responsive design
+- Match the design aesthetic of daily.totallife.com
+- Use Geist Sans and Geist Mono fonts (already configured)
+- Maintain consistent spacing with Tailwind's spacing scale
+- Use shadcn's theme system for consistent colors and dark mode
+
+## Code Standards
+
+- TypeScript strict mode enabled
+- ESLint configuration included
+- Use functional components with hooks
+- Prefer server components where possible (App Router)
+- Client components only when needed (interactivity, state)
+
+## Next Steps
+
+1. Implement core layout components (Header, Footer)
+2. Create article listing and detail pages
+3. Build AI search interface with streaming
+4. Add category filtering
+5. Integrate with FastAPI backend
+6. Implement podcast section
+7. Add newsletter form
+8. Polish UI/UX to match reference site
+
+## License
+
+Copyright 2025 Total Life. All Rights Reserved.

--- a/frontend/app/README.md
+++ b/frontend/app/README.md
@@ -1,0 +1,34 @@
+# App Directory
+
+Next.js App Router pages and API routes.
+
+## Structure
+
+### `/` (root)
+
+- `page.tsx` - Homepage with featured articles and category sections
+- `layout.tsx` - Root layout with Header/Footer
+- `globals.css` - Global styles and Tailwind imports
+
+### `/blog/[slug]`
+
+- `page.tsx` - Individual blog article page
+  Dynamic route for article slugs
+
+### `/category/[category]`
+
+- `page.tsx` - Category listing page
+  Filters articles by category (Nourishment, Restoration, Mindset, Relationships, Vitality)
+
+### `/search`
+
+- `page.tsx` - AI-powered search interface
+  Dedicated search page with streaming responses
+
+### `/api`
+
+Next.js API routes (if needed for server-side operations):
+
+- Could proxy requests to FastAPI backend
+- Handle authentication, session management
+- Server-side caching

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,1 +1,49 @@
 @import "tailwindcss";
+
+@theme {
+    --color-background: 0 0% 100%;
+    --color-foreground: 222.2 84% 4.9%;
+    --color-card: 0 0% 100%;
+    --color-card-foreground: 222.2 84% 4.9%;
+    --color-popover: 0 0% 100%;
+    --color-popover-foreground: 222.2 84% 4.9%;
+    --color-primary: 222.2 47.4% 11.2%;
+    --color-primary-foreground: 210 40% 98%;
+    --color-secondary: 210 40% 96.1%;
+    --color-secondary-foreground: 222.2 47.4% 11.2%;
+    --color-muted: 210 40% 96.1%;
+    --color-muted-foreground: 215.4 16.3% 46.9%;
+    --color-accent: 210 40% 96.1%;
+    --color-accent-foreground: 222.2 47.4% 11.2%;
+    --color-destructive: 0 84.2% 60.2%;
+    --color-destructive-foreground: 210 40% 98%;
+    --color-border: 214.3 31.8% 91.4%;
+    --color-input: 214.3 31.8% 91.4%;
+    --color-ring: 222.2 84% 4.9%;
+    --radius: 0.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+    @theme {
+        --color-background: 222.2 84% 4.9%;
+        --color-foreground: 210 40% 98%;
+        --color-card: 222.2 84% 4.9%;
+        --color-card-foreground: 210 40% 98%;
+        --color-popover: 222.2 84% 4.9%;
+        --color-popover-foreground: 210 40% 98%;
+        --color-primary: 210 40% 98%;
+        --color-primary-foreground: 222.2 47.4% 11.2%;
+        --color-secondary: 217.2 32.6% 17.5%;
+        --color-secondary-foreground: 210 40% 98%;
+        --color-muted: 217.2 32.6% 17.5%;
+        --color-muted-foreground: 215 20.2% 65.1%;
+        --color-accent: 217.2 32.6% 17.5%;
+        --color-accent-foreground: 210 40% 98%;
+        --color-destructive: 0 62.8% 30.6%;
+        --color-destructive-foreground: 210 40% 98%;
+        --color-border: 217.2 32.6% 17.5%;
+        --color-input: 217.2 32.6% 17.5%;
+        --color-ring: 212.7 26.8% 83.9%;
+    }
+}
+

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.ts",
+    "css": "app/globals.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/lib/hooks"
+  }
+}

--- a/frontend/components/README.md
+++ b/frontend/components/README.md
@@ -1,0 +1,114 @@
+# Components Directory
+
+React components organized by feature and responsibility.
+
+## Component Organization Pattern
+
+Components are organized into three main categories:
+
+### 1. **`/ui`** - shadcn/ui Components
+
+Pre-built, accessible components from shadcn/ui:
+
+- Installed via: `npx shadcn@latest add <component>`
+- Examples: button, card, input, dialog, dropdown-menu
+- Built on Radix UI primitives
+- Fully customizable and themed
+
+### 2. **`/common`** - Custom Reusable Components
+
+Your custom components used across the app:
+
+```
+common/
+├── Loading/
+│   ├── Loading.tsx          # Custom loading spinner
+│   └── index.ts
+├── ArticleCardSkeleton/
+│   ├── ArticleCardSkeleton.tsx
+│   └── index.ts
+└── AnimatedText/
+    ├── AnimatedText.tsx     # Framer Motion text animations
+    └── index.ts
+```
+
+### 3. **Feature-specific folders** - Domain Components
+
+Components grouped by feature domain:
+
+```
+components/
+├── blog/
+│   ├── ArticleCard/
+│   ├── ArticleGrid/
+│   └── ArticleHero/
+├── search/
+│   ├── SearchBar/
+│   ├── AIResponse/         # Waterfall text animation
+│   └── SearchResults/
+└── podcast/
+    ├── PodcastCard/
+    └── PodcastPlayer/
+```
+
+**Styling Approach:**
+
+- Primary: Tailwind CSS utility classes + shadcn/ui components
+- Animations: Framer Motion for smooth transitions
+- When needed: CSS Modules (`.module.css`) for complex styles
+- No global `/styles` folder - styles live with components
+- Global styles only in `app/globals.css` (Tailwind, CSS variables)
+
+## Structure
+
+### `/common`
+
+Reusable UI components used across the application:
+
+- Button, Card, Modal, Badge
+- Loading spinners, skeletons
+- Icons, Typography components
+
+### `/layout`
+
+Layout components that structure the pages:
+
+- Header (with navigation and search)
+- Footer
+- Sidebar
+- Navigation menus
+
+### `/blog`
+
+Blog-specific components:
+
+- ArticleCard - Preview card for blog articles
+- ArticleGrid - Grid layout for article lists
+- ArticleHero - Featured article hero section
+- CategoryBadge - Visual category indicators
+- ArticleContent - Rich text rendering for article body
+
+### `/search`
+
+AI-powered search components:
+
+- SearchBar - Main search input
+- SearchResults - Display search results
+- AIResponse - Streaming AI response with waterfall text effect
+- SearchSuggestions - Quick search suggestions
+
+### `/podcast`
+
+Podcast section components:
+
+- PodcastCard - Individual episode card
+- PodcastPlayer - Audio/video player
+- EpisodeList - List of recent episodes
+
+### `/forms`
+
+Form components:
+
+- NewsletterForm - Email subscription form
+- ContactForm - General contact form
+- Input, Textarea, Select - Reusable form controls

--- a/frontend/lib/README.md
+++ b/frontend/lib/README.md
@@ -1,0 +1,32 @@
+# Lib Directory
+
+Utility functions, API clients, and custom hooks.
+
+## Structure
+
+### `/api`
+
+API client functions for backend communication:
+
+- `articles.ts` - Article CRUD operations
+- `search.ts` - AI search endpoint integration
+- `categories.ts` - Category fetching
+- `client.ts` - Base HTTP client configuration
+
+### `/utils`
+
+General utility functions:
+
+- `formatters.ts` - Date, text formatting utilities
+- `validators.ts` - Form validation helpers
+- `constants.ts` - App-wide constants
+- `cn.ts` - Class name utility (for Tailwind)
+
+### `/hooks`
+
+Custom React hooks:
+
+- `useArticles.ts` - Fetch and manage articles
+- `useSearch.ts` - Handle AI search state and streaming
+- `useDebounce.ts` - Debounce user input
+- `useIntersectionObserver.ts` - Infinite scroll, lazy loading

--- a/frontend/lib/utils/cn.ts
+++ b/frontend/lib/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}

--- a/frontend/lib/utils/index.ts
+++ b/frontend/lib/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './cn';

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,15 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "framer-motion": "^12.23.24",
+        "lucide-react": "^0.555.0",
         "next": "16.0.5",
         "react": "19.2.0",
-        "react-dom": "19.2.0"
+        "react-dom": "19.2.0",
+        "tailwind-merge": "^3.4.0",
+        "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -2589,11 +2595,32 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3604,6 +3631,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.23.24",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
+      "integrity": "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/function-bind": {
@@ -4861,6 +4915,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.555.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.555.0.tgz",
+      "integrity": "sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4927,6 +4990,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -6047,12 +6125,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
+      "integrity": "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
     },
     "node_modules/tapable": {
       "version": "2.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,15 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "framer-motion": "^12.23.24",
+    "lucide-react": "^0.555.0",
     "next": "16.0.5",
     "react": "19.2.0",
-    "react-dom": "19.2.0"
+    "react-dom": "19.2.0",
+    "tailwind-merge": "^3.4.0",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,56 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+    content: [
+        "./pages/**/*.{js,ts,jsx,tsx,mdx}",
+        "./components/**/*.{js,ts,jsx,tsx,mdx}",
+        "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    ],
+    theme: {
+        extend: {
+            colors: {
+                background: "hsl(var(--color-background) / <alpha-value>)",
+                foreground: "hsl(var(--color-foreground) / <alpha-value>)",
+                card: {
+                    DEFAULT: "hsl(var(--color-card) / <alpha-value>)",
+                    foreground: "hsl(var(--color-card-foreground) / <alpha-value>)",
+                },
+                popover: {
+                    DEFAULT: "hsl(var(--color-popover) / <alpha-value>)",
+                    foreground: "hsl(var(--color-popover-foreground) / <alpha-value>)",
+                },
+                primary: {
+                    DEFAULT: "hsl(var(--color-primary) / <alpha-value>)",
+                    foreground: "hsl(var(--color-primary-foreground) / <alpha-value>)",
+                },
+                secondary: {
+                    DEFAULT: "hsl(var(--color-secondary) / <alpha-value>)",
+                    foreground: "hsl(var(--color-secondary-foreground) / <alpha-value>)",
+                },
+                muted: {
+                    DEFAULT: "hsl(var(--color-muted) / <alpha-value>)",
+                    foreground: "hsl(var(--color-muted-foreground) / <alpha-value>)",
+                },
+                accent: {
+                    DEFAULT: "hsl(var(--color-accent) / <alpha-value>)",
+                    foreground: "hsl(var(--color-accent-foreground) / <alpha-value>)",
+                },
+                destructive: {
+                    DEFAULT: "hsl(var(--color-destructive) / <alpha-value>)",
+                    foreground: "hsl(var(--color-destructive-foreground) / <alpha-value>)",
+                },
+                border: "hsl(var(--color-border) / <alpha-value>)",
+                input: "hsl(var(--color-input) / <alpha-value>)",
+                ring: "hsl(var(--color-ring) / <alpha-value>)",
+            },
+            borderRadius: {
+                lg: "var(--radius)",
+                md: "calc(var(--radius) - 2px)",
+                sm: "calc(var(--radius) - 4px)",
+            },
+        },
+    },
+    plugins: [],
+};
+
+export default config;

--- a/frontend/types/article.ts
+++ b/frontend/types/article.ts
@@ -1,0 +1,76 @@
+/**
+ * Category types matching the Total Life pillars
+ */
+export type ArticleCategory =
+    | 'nourishment'
+    | 'restoration'
+    | 'mindset'
+    | 'relationships'
+    | 'vitality';
+
+/**
+ * Article metadata and content structure
+ */
+export interface Article {
+    id: string;
+    slug: string;
+    title: string;
+    excerpt: string;
+    content: string;
+    category: ArticleCategory;
+    author?: {
+        name: string;
+        avatar?: string;
+    };
+    publishedAt: string;
+    updatedAt?: string;
+    featuredImage?: {
+        url: string;
+        alt: string;
+    };
+    tags?: string[];
+    readTimeMinutes?: number;
+    isFeatured?: boolean;
+}
+
+/**
+ * Simplified article preview for listings
+ */
+export interface ArticlePreview {
+    id: string;
+    slug: string;
+    title: string;
+    excerpt: string;
+    category: ArticleCategory;
+    publishedAt: string;
+    featuredImage?: {
+        url: string;
+        alt: string;
+    };
+    readTimeMinutes?: number;
+    isFeatured?: boolean;
+}
+
+/**
+ * Paginated article response
+ */
+export interface ArticleListResponse {
+    articles: ArticlePreview[];
+    pagination: {
+        page: number;
+        pageSize: number;
+        totalPages: number;
+        totalItems: number;
+    };
+}
+
+/**
+ * Category metadata
+ */
+export interface Category {
+    id: ArticleCategory;
+    name: string;
+    description: string;
+    icon?: string;
+    color?: string;
+}

--- a/frontend/types/common.ts
+++ b/frontend/types/common.ts
@@ -1,0 +1,38 @@
+/**
+ * Common API response wrapper
+ */
+export interface ApiResponse<T> {
+    success: boolean;
+    data?: T;
+    error?: {
+        code: string;
+        message: string;
+        details?: Record<string, unknown>;
+    };
+    meta?: {
+        timestamp: string;
+        requestId?: string;
+    };
+}
+
+/**
+ * API error
+ */
+export interface ApiError {
+    code: string;
+    message: string;
+    status: number;
+    details?: Record<string, unknown>;
+}
+
+/**
+ * Newsletter subscription
+ */
+export interface NewsletterSubscription {
+    email: string;
+    name?: {
+        first: string;
+        last: string;
+    };
+    phone?: string;
+}

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Central export point for all types
+ */
+
+export * from './article';
+export * from './search';
+export * from './podcast';
+export * from './common';

--- a/frontend/types/podcast.ts
+++ b/frontend/types/podcast.ts
@@ -1,0 +1,37 @@
+/**
+ * Podcast episode types
+ */
+
+export interface PodcastEpisode {
+    id: string;
+    title: string;
+    description: string;
+    publishedAt: string;
+    duration: number; // in seconds
+    audioUrl?: string;
+    videoUrl?: string;
+    youtubeUrl?: string;
+    spotifyUrl?: string;
+    applePodcastsUrl?: string;
+    thumbnail?: {
+        url: string;
+        alt: string;
+    };
+    guests?: {
+        name: string;
+        title: string;
+        avatar?: string;
+    }[];
+    topics?: string[];
+}
+
+/**
+ * Podcast player state
+ */
+export interface PlayerState {
+    isPlaying: boolean;
+    currentTime: number;
+    duration: number;
+    volume: number;
+    isMuted: boolean;
+}

--- a/frontend/types/search.ts
+++ b/frontend/types/search.ts
@@ -1,0 +1,72 @@
+/**
+ * AI Search types
+ */
+
+/**
+ * User search query
+ */
+export interface SearchQuery {
+    query: string;
+    filters?: {
+        categories?: string[];
+        dateRange?: {
+            from: string;
+            to: string;
+        };
+    };
+}
+
+/**
+ * AI-generated search response
+ */
+export interface AISearchResponse {
+    id: string;
+    query: string;
+    answer: string; // Markdown formatted response
+    sources?: SearchSource[];
+    relatedArticles?: RelatedArticle[];
+    timestamp: string;
+}
+
+/**
+ * Source citation for AI response
+ */
+export interface SearchSource {
+    title: string;
+    url: string;
+    excerpt: string;
+    relevanceScore?: number;
+}
+
+/**
+ * Related article suggestion
+ */
+export interface RelatedArticle {
+    id: string;
+    slug: string;
+    title: string;
+    excerpt: string;
+    category: string;
+}
+
+/**
+ * Streaming response chunk for waterfall effect
+ */
+export interface StreamChunk {
+    type: 'token' | 'complete' | 'error';
+    content?: string;
+    metadata?: {
+        sources?: SearchSource[];
+        relatedArticles?: RelatedArticle[];
+    };
+    error?: string;
+}
+
+/**
+ * Search suggestions
+ */
+export interface SearchSuggestion {
+    text: string;
+    category?: string;
+    popularity?: number;
+}


### PR DESCRIPTION
This pull request sets up foundational documentation, configuration, and utility code for the Total Life Daily frontend project. It introduces comprehensive README files for key directories, configures shadcn/ui integration, adds essential styling variables, and brings in utility libraries and functions to support scalable React development.

**Project Documentation & Structure**

* Added detailed `README.md` files for the main `frontend/`, `app/`, `components/`, and `lib/` directories, outlining project goals, tech stack, folder structure, and development guidelines. [[1]](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543R1-R259) [[2]](diffhunk://#diff-4426b76038e268c7b481af4296cf122bbfcfde728baff40b3b14313530db4863R1-R34) [[3]](diffhunk://#diff-40ad6c3cfc967fa8069a6fbe67552423099690455795d04344e7e20c1f63a977R1-R114) [[4]](diffhunk://#diff-f2f3b11d2a546e0f17bae09aab804e26ffb727f6515c17ebc0819574c15219afR1-R32)

**Styling & UI Configuration**

* Introduced global CSS variables for theming and dark mode in `app/globals.css`, establishing a style foundation for Tailwind and shadcn/ui components.
* Added `components.json` to configure shadcn/ui, including style, Tailwind integration, and custom path aliases for streamlined imports.

**Utility & Library Setup**

* Implemented a reusable `cn` utility function in `lib/utils/cn.ts` for merging Tailwind and custom class names, and exported it via `lib/utils/index.ts`. [[1]](diffhunk://#diff-5f0f219a21e002d80d9d77199a4243c1ee910bc2f578cce230ea534f582994f5R1-R6) [[2]](diffhunk://#diff-392504991a3f1f5f665fe5c9f599b84e4ebb19340b7dcafd4dd5754580a36f9eR1)
* Updated dependencies in `package.json` and `package-lock.json` to include `clsx`, `tailwind-merge`, `framer-motion`, `lucide-react`, `class-variance-authority`, and `tailwindcss-animate`, supporting advanced UI, animation, and utility patterns. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R12-R20) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR11-R19) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR2598-R2624) [[4]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR3636-R3662) [[5]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR4918-R4926) [[6]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR4994-R5008) [[7]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR6128-R6152)